### PR TITLE
Rake generator initialize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: ruby
+addons:
+  postgresql: "9.4"
 rvm:
  - "2.2.1"
 cache: bundler
+bundler_args: --without production development
+before_install:
+  - gem install bundler
 before_script:
   - "for i in config/*.example; do cp \"$i\" \"${i/.example}\"; done"
-  - bundle exec rake sunspot:solr:start
-  - bundle exec rake db:setup
-script: bundle exec rake
+  - bundle exec rake db:drop db:create db:migrate
+script:
+  - RAILS_ENV=test bundle exec rake assets:precompile
+  - RAILS_ENV=test bundle exec rake sunspot:solr:start
+  - RAILS_ENV=test bundle exec rspec spec
+  - RAILS_ENV=test bundle exec rake sunspot:solr:stop

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,7 +2,7 @@ class Event < ActiveRecord::Base
   include PublicActivity::Model
 
   tracked owner: Proc.new { |controller, model| controller && controller.current_user }
-  tracked title: Proc.new { |controller, model| controller.get_title }
+  tracked title: Proc.new { |controller, model| controller && controller.get_title }
 
   extend FriendlyId
   friendly_id :title, use: [:slugged, :finders]


### PR DESCRIPTION
What
====
There is a bug when running rake task to initialize database with fake sample data.

**Command**
The command who throws the exception is:
```
rake generator:initialize
```

When application tries to save public activity throws next exception:
```
rake aborted!
NoMethodError: undefined method `get_title' for nil:NilClass
/Users/sendero/dev/railsworkspace/agendas-1/app/models/event.rb:5:in `block in <class:Event>'
```

How
===
Adding a condition to allow running task normally.

